### PR TITLE
Parser chain

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
 flake8==2.4.1
-pylint==1.4.3
+pylint==1.4.4
 nosexcover==1.0.10
-mock==1.2.0
+mock==1.3.0

--- a/doc/ref/inputers/all/index.rst
+++ b/doc/ref/inputers/all/index.rst
@@ -16,6 +16,7 @@ Example input event:
     {
       'hostname': 'localhost',
       'message': '127.0.0.1 - - [13/Mar/2014:13:46:00 -0400] "GET / HTTP/1.1" 200 6301 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0" "6.57"',
+      'time_stamp': '2014-03-13T13:46:00',
       'type': 'nginx',
     }
 

--- a/doc/ref/parsers/all/index.rst
+++ b/doc/ref/parsers/all/index.rst
@@ -13,7 +13,7 @@ Example parsed event:
     {
       'hostname': 'localhost',
       'remote_addr': '127.0.0.1',
-      'time': '13/Mar/2014:13:46:00',
+      'time_stamp': '2014-03-13T13:46:00',
       'request': '/',
       'status': '200',
       'bytes_send': '6301',
@@ -30,3 +30,4 @@ Full List of Parsers
 .. toctree::
 
     yalp.parsers.regex
+    yalp.parsers.timestamp

--- a/doc/ref/parsers/all/yalp.parsers.timestamp.rst
+++ b/doc/ref/parsers/all/yalp.parsers.timestamp.rst
@@ -1,0 +1,2 @@
+
+.. automodule:: yalp.parsers.timestamp

--- a/opt_requirements.txt
+++ b/opt_requirements.txt
@@ -1,2 +1,2 @@
 elasticsearch==1.6.0
-pymongo==3.0.2
+pymongo==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==3.11
 celery==3.1.18
 python-dateutil==2.4.2
+pygrok==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML==3.11
 celery==3.1.18
+python-dateutil==2.4.2

--- a/tests/core/test_parser_task.py
+++ b/tests/core/test_parser_task.py
@@ -24,4 +24,4 @@ class TestParserTask(YalpTestCase):
             'message': 'test message',
         }
         result = tasks.process_message.apply(args=[event])
-        self.assertIn(event, result.result)
+        self.assertEqual(event, result.result)

--- a/tests/parsers/test_grok.py
+++ b/tests/parsers/test_grok.py
@@ -1,0 +1,33 @@
+# vim: set et ts=4 sw=4 fileencoding=utf-8:
+'''
+tests.parsers.test_grok
+=======================
+'''
+import unittest
+from yalp.parsers import grok
+
+
+class TestGrokParser(unittest.TestCase):
+    '''
+    Test the grok.Parser
+    '''
+
+    def test_parse_event(self):
+        event = {
+            'message': '192.168.0.1 GET /index.html',
+            'time_stamp': '2015-01-01T01:00:00',
+            'hostname': 'server_hostname',
+        }
+        parser = grok.Parser(
+            pattern='%{IP:ip_addr} %{WORD:request_type} %{URIPATHPARAM:path}'
+        )
+        parsed_event = parser.run(event)
+        expected = {
+            'message': '192.168.0.1 GET /index.html',
+            'time_stamp': '2015-01-01T01:00:00',
+            'hostname': 'server_hostname',
+            'ip_addr': '192.168.0.1',
+            'request_type': 'GET',
+            'path': '/index.html',
+        }
+        self.assertDictEqual(expected, parsed_event)

--- a/tests/parsers/test_passthrough.py
+++ b/tests/parsers/test_passthrough.py
@@ -30,4 +30,4 @@ class TestPassthroughParser(unittest.TestCase):
         }
         parser = passthrough.Parser()
         parsed_event = parser.run(event)
-        self.assertIsNone(parsed_event)
+        self.assertDictEqual(event, parsed_event)

--- a/tests/parsers/test_regex.py
+++ b/tests/parsers/test_regex.py
@@ -38,7 +38,7 @@ class TestRegexParser(unittest.TestCase):
         }
         parser = regex.Parser(regex=r'(?P<month>\w+)\s+(?P<day>\d+)')
         parsed_event = parser.run(event)
-        self.assertIsNone(parsed_event)
+        self.assertDictEqual(event, parsed_event)
 
     def test_parse_event_skip_on_type(self):
         event = {
@@ -48,4 +48,4 @@ class TestRegexParser(unittest.TestCase):
         }
         parser = regex.Parser(regex=r'(?P<month>\w+)\s+(?P<day>\d+)')
         parsed_event = parser.run(event)
-        self.assertIsNone(parsed_event)
+        self.assertDictEqual(event, parsed_event)

--- a/tests/parsers/test_timestamp.py
+++ b/tests/parsers/test_timestamp.py
@@ -1,0 +1,24 @@
+# vim: set et ts=4 sw=4 fileencoding=utf-8:
+'''
+tests.parsers.test_timestamp
+============================
+'''
+import unittest
+from yalp.parsers import timestamp
+
+
+class TestTimestampParser(unittest.TestCase):
+    '''
+    Test the timestamp.Parser
+    '''
+
+    def test_parse_event(self):
+        event = {
+            'host': 'localhost',
+            'message': u'127.0.0.1 - - [13/Mar/2014:13:46:00 -0400] "GET / HTTP/1.1" 200 6301 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0" "6.57"',
+            'date_field': u'13/Mar/2014:13:46:00 -0400',
+            'time_stamp': '2015-01-01T00:00:00',
+        }
+        parser = timestamp.Parser(field='date_field')
+        parsed_event = parser.run(event)
+        self.assertEqual('2014-03-13T13:46:00', parsed_event['time_stamp'])

--- a/yalp/parsers/grok.py
+++ b/yalp/parsers/grok.py
@@ -31,7 +31,7 @@ With an input event like the following:
 .. code-block:: python
 
     {
-        'messaage': '192.168.0.1 GET /index.html'
+        'message': '192.168.0.1 GET /index.html',
         'time_stamp': '2015-01-01T01:00:00',
         'hostname': 'server_hostname',
     }
@@ -41,7 +41,7 @@ After the parser runs, the event will become:
 .. code-block:: python
 
     {
-        'messaage': '192.168.0.1 GET /index.html'
+        'message': '192.168.0.1 GET /index.html',
         'time_stamp': '2015-01-01T01:00:00',
         'hostname': 'server_hostname',
         'ip_addr': '192.168.0.1',
@@ -60,7 +60,7 @@ class Parser(BaseParser):
     '''
     Process input with grok pattern match.
     '''
-    def __init__(self, field='mesage', pattern=None, *args, **kwargs):
+    def __init__(self, field='message', pattern=None, *args, **kwargs):
         super(Parser, self).__init__(*args, **kwargs)
         self.pattern = pattern
         self.field = field

--- a/yalp/parsers/grok.py
+++ b/yalp/parsers/grok.py
@@ -1,0 +1,72 @@
+# vim: set et ts=4 sw=4 fileencoding=utf-8:
+'''
+yalp.parsers.grok
+=================
+
+Use `grok`_ to parse the event. Any matched fields from the grok pattern
+will be added to the event.
+
+This parser supports the following connfiguration items:
+
+**pattern**
+    A grok pattern to match. See `available patterns`_ for details.
+
+*field*
+    The field from the event to parse. Defaults to ``message``.
+
+*type*
+    A type filter. Events not of this type will be skipped.
+
+
+Example configuration.
+
+.. code-block:: yaml
+
+    parsers:
+      - grok:
+        pattern: '%{IP:ip_addr} %{WORD:request_type} %{URIPATHPARAM:path}'
+
+With an input event like the following:
+
+.. code-block:: python
+
+    {
+        'messaage': '192.168.0.1 GET /index.html'
+        'time_stamp': '2015-01-01T01:00:00',
+        'hostname': 'server_hostname',
+    }
+
+After the parser runs, the event will become:
+
+.. code-block:: python
+
+    {
+        'messaage': '192.168.0.1 GET /index.html'
+        'time_stamp': '2015-01-01T01:00:00',
+        'hostname': 'server_hostname',
+        'ip_addr': '192.168.0.1',
+        'request_type': 'GET',
+        'path': '/index.html',
+    }
+
+.. _available patterns: https://github.com/garyelephant/pygrok/tree/master/pygrok/patterns
+.. _grok: https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html#plugins-filters-grok
+'''
+import pygrok
+from . import BaseParser
+
+
+class Parser(BaseParser):
+    '''
+    Process input with grok pattern match.
+    '''
+    def __init__(self, field='mesage', pattern=None, *args, **kwargs):
+        super(Parser, self).__init__(*args, **kwargs)
+        self.pattern = pattern
+        self.field = field
+
+    def parse(self, event):
+        matches = pygrok.grok_match(event[self.field], self.pattern)
+        if matches:
+            event.update(matches)
+        return event

--- a/yalp/parsers/regex.py
+++ b/yalp/parsers/regex.py
@@ -13,9 +13,7 @@ matched strings becoming the values.
 This parser supports the following configuration items:
 
 **regex**
-    The regex to apply.
-*type*
-    A type filter. Only apply the regex to events of this type.
+    The regex to apply.  *type* A type filter. Only apply the regex to events of this type.
 
 
 Example configuration.
@@ -44,6 +42,4 @@ class Parser(BaseParser):
         match = re.match(self.regex, message)
         if match:
             event.update(match.groupdict())
-            return event
-        else:
-            return None
+        return event

--- a/yalp/parsers/regex.py
+++ b/yalp/parsers/regex.py
@@ -13,7 +13,10 @@ matched strings becoming the values.
 This parser supports the following configuration items:
 
 **regex**
-    The regex to apply.  *type* A type filter. Only apply the regex to events of this type.
+    The regex to apply.
+
+*type*
+    A type filter. Only apply the regex to events of this type.
 
 
 Example configuration.

--- a/yalp/parsers/timestamp.py
+++ b/yalp/parsers/timestamp.py
@@ -22,6 +22,7 @@ The parser supports the following configuration items:
 *type*
     A type filter. Events not of this type will be skipped.
 
+
 Examaple configuration.
 
 .. code-block:: yaml

--- a/yalp/parsers/timestamp.py
+++ b/yalp/parsers/timestamp.py
@@ -19,6 +19,9 @@ The parser supports the following configuration items:
     The `date format`_ string to format the time stamp. Defaults to
     ``%Y-%m-%dT$H:%M:%S``.
 
+*type*
+    A type filter. Events not of this type will be skipped.
+
 Examaple configuration.
 
 .. code-block:: yaml
@@ -53,7 +56,7 @@ class Parser(BaseParser):
 
     def parse(self, event):
         if self.field in event:
-            event[self.out_field] = dt_parse(
+            event[self.out_field] = dt_parse(  # pylint: disable=no-member
                 event[self.field],
                 fuzzy=True
             ).strftime(self.timestamp_fmt)

--- a/yalp/parsers/timestamp.py
+++ b/yalp/parsers/timestamp.py
@@ -1,0 +1,60 @@
+# vim: set et ts=4 sw=4 fileencoding=utf-8:
+'''
+yalp.parsers.timestamp
+======================
+
+Used to set the event time_stamp from another field in the event.
+
+The parser supports the following configuration items:
+
+**field**
+    The field to parse for a datetime. If the field is not found in the
+    event, the event will be skipped.
+
+*out_field*
+    The field to write the parsed time stamp to. Defaults to
+    ``time_stamp``.
+
+*timestamp_fmt*
+    The `date format`_ string to format the time stamp. Defaults to
+    ``%Y-%m-%dT$H:%M:%S``.
+
+Examaple configuration.
+
+.. code-block:: yaml
+
+    parsers:
+      - timestamp:
+          field: date_field
+
+.. _date format: https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+'''
+from dateutil.parser import parse as dt_parse
+
+from . import BaseParser
+
+DEFAULT_DATE_FMT = '%Y-%m-%dT%H:%M:%S'
+
+
+class Parser(BaseParser):
+    '''
+    Search for datetime string and set time_stamp.
+    '''
+    def __init__(self,
+                 field,
+                 out_field='time_stamp',
+                 timestamp_fmt=DEFAULT_DATE_FMT,
+                 *args,
+                 **kwargs):
+        super(Parser, self).__init__(*args, **kwargs)
+        self.field = field
+        self.out_field = out_field
+        self.timestamp_fmt = timestamp_fmt
+
+    def parse(self, event):
+        if self.field in event:
+            event[self.out_field] = dt_parse(
+                event[self.field],
+                fuzzy=True
+            ).strftime(self.timestamp_fmt)
+        return event

--- a/yalp/pipeline/__init__.py
+++ b/yalp/pipeline/__init__.py
@@ -32,7 +32,7 @@ class CeleryPipeline(BasePipline):
             self.logger.info('%s skipping event %s: not same type',
                              self.__class__.__name__,
                              event)
-            return None
+            return event
         else:
             self.logger.info('processing event %s', event)
             return self.process_event(event)

--- a/yalp/pipeline/tasks.py
+++ b/yalp/pipeline/tasks.py
@@ -148,11 +148,18 @@ def process_message(event):
     '''
     Process a message using settings from config.
 
-    message
-        The message to process, generally a string.
+    event
+        The event to process. A dict containing the message. For example:
+
+        .. code-block:: python
+
+            {
+                'message': 'the message to parse',
+                'time_stamp': '2015-01-01T01:00:00',
+                'hostname': 'input_host',
+            }
     '''
-    parsed_events = [parser.run(event) for parser in process_message.parsers]
-    for parsed_event in parsed_events:
-        if parsed_event:
-            process_output(event)
-    return parsed_events
+    for parser in process_message.parsers:
+        event = parser.run(event)
+    process_output(event)
+    return event


### PR DESCRIPTION
Make parser a chain so each parser passed events to the next. This allows for building a parsing pipeline from reusable parsers